### PR TITLE
Make in command a no-op so out command works

### DIFF
--- a/lib/bosh_config_resource/in_command.rb
+++ b/lib/bosh_config_resource/in_command.rb
@@ -9,7 +9,7 @@ module BoshConfigResource
     end
 
     def run(_working_dir, _request)
-      raise 'not implemented'
+      puts '{"version":{"ref":"none"}}'
     end
 
     private


### PR DESCRIPTION
When you do a `put` in Concourse, it does an implicit `get` afterward. With the `in` command here always throwing an error, `put`s do their job but the job fails because of the in afterward. This is problematic if the job is in the middle of a pipeline. This will resolve the issue by still making the `in` command not actually do anything, but it will work in a `put` context. 